### PR TITLE
Support binnary response

### DIFF
--- a/ApiCodeGenerator.OpenApi.Refit.Tests/FunctionalTests.cs
+++ b/ApiCodeGenerator.OpenApi.Refit.Tests/FunctionalTests.cs
@@ -541,5 +541,31 @@ namespace ApiCodeGenerator.OpenApi.Refit.Tests
             //Act & Assert
             RunTest(settings, expected, "authSchema.json");
         }
+
+        [Test]
+        public void GenerateClientInterface_BinaryResponse()
+        {
+            var settings = new RefitCodeGeneratorSettings
+            {
+                BinaryResponseType = "System.Net.Http.HttpContent",
+                GenerateClientInterfaces = true,
+                GenerateOptionalParameters = false,
+                CSharpGeneratorSettings =
+                {
+                    Namespace = "TestNS",
+                },
+            };
+
+            var expected =
+                "    public partial interface IClient\n" +
+                "    {\n" +
+                "        /// <exception cref=\"Refit.ApiException\">A server side error occurred.</exception>\n" +
+                "        [Get(\"/download\")]\n" +
+                "        System.Threading.Tasks.Task<System.Net.Http.HttpContent> Download();\n" +
+                "\n" +
+                "    }\n";
+
+            RunTest(settings, expected, "streamResponse.yaml", "    \n");
+        }
     }
 }

--- a/ApiCodeGenerator.OpenApi.Refit.Tests/swagger/streamResponse.yaml
+++ b/ApiCodeGenerator.OpenApi.Refit.Tests/swagger/streamResponse.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0.0"
+paths:
+  /download:
+    get:
+      responses:
+        "200":
+          description: ""
+          content:
+            "application/json":
+              schema:
+                type: string
+                format: binary

--- a/ApiCodeGenerator.OpenApi.Refit/RefitCodeGenerator.cs
+++ b/ApiCodeGenerator.OpenApi.Refit/RefitCodeGenerator.cs
@@ -31,7 +31,12 @@ namespace ApiCodeGenerator.OpenApi.Refit
             OpenApiDocument = openApiDocument;
             BaseSettings = settings;
             _settings = settings;
-            _settings.CSharpGeneratorSettings.ExcludedTypeNames = ["FileParameter", .. _settings.CSharpGeneratorSettings.ExcludedTypeNames];
+            _settings.CSharpGeneratorSettings.ExcludedTypeNames =
+                [
+                    "FileParameter",
+                    "FileResponse",
+                    .. _settings.CSharpGeneratorSettings.ExcludedTypeNames
+                ];
             SetUsages();
         }
 
@@ -47,6 +52,8 @@ namespace ApiCodeGenerator.OpenApi.Refit
         /// OpenApi документ.
         /// </summary>
         protected OpenApiDocument OpenApiDocument { get; }
+
+        public override string GetBinaryResponseTypeName() => _settings.BinaryResponseType;
 
         /// <inheritdoc />
         protected override IEnumerable<CodeArtifact> GenerateClientTypes(string controllerName, string controllerClassName, IEnumerable<CSharpOperationModel> operations)

--- a/ApiCodeGenerator.OpenApi.Refit/RefitCodeGeneratorSettings.cs
+++ b/ApiCodeGenerator.OpenApi.Refit/RefitCodeGeneratorSettings.cs
@@ -69,5 +69,10 @@ namespace ApiCodeGenerator.OpenApi.Refit
         /// Тип используемый для двоичного содержимого.
         /// </summary>
         public string BinaryPartType { get; set; } = "StreamPart";
+
+        /// <summary>
+        /// Тип используемый для двоичного ответа.
+        /// </summary>
+        public string BinaryResponseType { get; set; } = "System.IO.Stream";
     }
 }

--- a/schemas/nswag.json
+++ b/schemas/nswag.json
@@ -78,6 +78,11 @@
               "type": "string",
               "description": "The .NET type used for binary data (default: StreamPart).",
               "default": "StreamPart"
+            },
+            "binaryResponseType": {
+              "type": "string",
+              "description": "The .NET type used for binary response (default: System.IO.Stream).",
+              "default": "System.IO.Stream"
             }
           }
         }


### PR DESCRIPTION
Added support for responses in binary format.
Use `binaryResponseType` setting (default: `System.IO.Stream`) to customize the return type of the operation.